### PR TITLE
runs (resolves #5 and #12)

### DIFF
--- a/public/configs/example-options-simple.json
+++ b/public/configs/example-options-simple.json
@@ -2,13 +2,15 @@
   "title": "Example Options",
   "description": "yes options, no dictionary, no string interpolation",
   "default": {
-    "models": ["REMIND-MAgPIE 1.7-3.0"],
-    "scenarios": [
-      "PEP_1p5C_full_NDC",
-      "PEP_1p5C_full_netzero",
-      "PEP_1p5C_full_eff"
+    "runs": [
+      ["REMIND-MAgPIE 1.7-3.0", "PEP_1p5C_full_NDC"],
+      ["REMIND-MAgPIE 1.7-3.0", "PEP_1p5C_full_netzero"],
+      ["REMIND-MAgPIE 1.7-3.0", "PEP_1p5C_full_eff"],
+      ["MESSAGE-GLOBIOM 1.0", "SSP2-Baseline"],
+      ["REMIND-MAgPIE 1.5", "SSP2-Baseline"]
     ],
-    "regions": ["World"]
+    "regions": ["World"],
+    "primaryDimension": "runs"
   },
   "dropdowns": [{
     "label": "Variables",
@@ -25,6 +27,20 @@
         "Carbon Sequestration|Land Use|Afforestation"
       ]
     }]
+  }, {
+    "label": "Primary Dimension",
+    "options": [{
+      "label": "runs",
+      "primaryDimension": "runs"
+    }, {
+      "label": "models",
+      "primaryDimension": "models"
+    }, {
+      "label": "scenarios",
+      "primaryDimension": "scenarios"
+    }]
   }],
-  "primaryDimension": "scenarios"
+  "dict": {
+    "REMIND-MAgPIE 1.7-3.0 | PEP_1p5C_full_NDC": "dictionary test for runs"
+  }
 }

--- a/src/store.js
+++ b/src/store.js
@@ -145,8 +145,6 @@ async function getTimeseries ({ token, config, runs, options, colors }) {
     })
   })
 
-  console.log(data)
-
   const units = [...new Set(timeseries.map(ts => ts.unit))]
   const domains = {}
   units.forEach(u => {
@@ -187,7 +185,6 @@ async function getTimeseries ({ token, config, runs, options, colors }) {
       within
     }
   })
-  console.log(panels)
   return { data: panels, current, domains }
 }
 

--- a/src/views/Gem.vue
+++ b/src/views/Gem.vue
@@ -16,8 +16,8 @@
         </div>
       </div>
       <div class="legend" v-if="current != null">
-        <div class="tiny label">{{ config.primaryDimension }}</div>
-        <span v-for="(o, i) in current[config.primaryDimension]" :key="`o${i}`"
+        <div class="tiny label">{{ current.primaryDimension }}</div>
+        <span v-for="(o, i) in current[current.primaryDimension]" :key="`o${i}`"
           class="tiny" :class="{ transparent: highlight != null && highlight != o }"
           @mouseenter="highlight = o" @mousemove="highlight = o" @mouseout="highlight = null">
           <span class="glyph-dot" :class="[colors[i]]"/>
@@ -27,7 +27,7 @@
       <div class="group" v-for="(g, i) in groups" :key="`g-${i}`">
         <h3 v-if="g.label">{{g.label}}</h3>
         <div class="panels">
-          <ChartLine v-for="(p, j) in g.data" :key="`${i}-${j}`" :colors="colors" v-bind="p"
+          <ChartLine v-for="(p, j) in g.data.filter(p => p.within.length > 0)" :key="`${i}-${j}`" :colors="colors" v-bind="p"
             :number-format="config.numberFormat" :highlight="highlight"
             :domain="synchronize ? domains[p.within[0].unit] : null"/>
         </div>
@@ -87,7 +87,8 @@ export default {
     },
     groups () {
       const { current, data } = this
-      if (current == null) return
+      console.log(data)
+      if (current == null || data == null) return
       if (current.groups == null) return [{ data }]
       let start = 0
       return current.groups.map(g => {

--- a/src/views/Gem.vue
+++ b/src/views/Gem.vue
@@ -87,7 +87,6 @@ export default {
     },
     groups () {
       const { current, data } = this
-      console.log(data)
       if (current == null || data == null) return
       if (current.groups == null) return [{ data }]
       let start = 0


### PR DESCRIPTION
proposal to use runs that specify models and scenarios instead of setting them globally

**this update requires modification of all gem configs**

## changes

runs can be specified as arrays where the first string is the model and the second string the scenario:
```
"runs": [
  ["REMIND-MAgPIE 1.7-3.0", "PEP_1p5C_full_NDC"],
  ["REMIND-MAgPIE 1.7-3.0", "PEP_1p5C_full_netzero"],
  ["REMIND-MAgPIE 1.7-3.0", "PEP_1p5C_full_eff"],
  ["MESSAGE-GLOBIOM 1.0", "SSP2-Baseline"],
  ["REMIND-MAgPIE 1.5", "SSP2-Baseline"]
]
```

`primaryDimension` can now be set to `runs` while `models` and `scenarios` remains working.
**The `primaryDimension` attributes has moved** and is now a child of `default: {…}`. This allows overwriting this attribute with dropdowns.

In the key labels for runs are generated by concatenating models and scenarios
(i.e.; `${model} | ${scenario}`), they can be overwritten by adding dictionary entries:
```
"dict": {
  "REMIND-MAgPIE 1.7-3.0 | PEP_1p5C_full_NDC": "dictionary test for runs"
}
```

## demo
running example: https://gems-jbbawlpu0.now.sh/#/example-options-simple

see this for updating configs: https://github.com/SensesProject/gems/commit/4233680b6f0f3c3be2ab132f883ffbb748ee8340 

