### PR TITLE
Brace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1963,6 +1963,37 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -3023,6 +3054,14 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "copy-webpack-plugin": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.6.0.tgz",
@@ -3546,9 +3585,9 @@
       "integrity": "sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg=="
     },
     "d3-delaunay": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.1.6.tgz",
-      "integrity": "sha512-VF6bxon2bn1cdXuesInEtVKlE4aUfq5IjE5y0Jl2aZP1yvLsf0QENqQxNhjS4vq95EmYKauA30ofTwvREtPSXA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.2.1.tgz",
+      "integrity": "sha512-ZZdeJl6cKRyqYVFYK+/meXvWIrAvZsZTD7WSxl4OPXCmuXNgDyACAClAJHD63zL25TA+IJGURUNO7rFseNFCYw==",
       "requires": {
         "delaunator": "4"
       }
@@ -7197,9 +7236,11 @@
       }
     },
     "library": {
-      "version": "github:SensesProject/library#26bab5d451fcea848fc6b0af58459d30d3208a3b",
-      "from": "github:SensesProject/library#1.2.0",
+      "version": "github:SensesProject/library#3683b088683655d3170835b497046d892fb4c53b",
+      "from": "github:SensesProject/library",
       "requires": {
+        "axios": "^0.19.2",
+        "copy-to-clipboard": "^3.2.1",
         "d3-delaunay": "^5.1.5",
         "d3-dsv": "^1.1.1",
         "d3-scale": "^3.1.0",
@@ -7207,6 +7248,7 @@
         "normalize-scss": "^7.0.1",
         "v-tooltip": "^2.0.2",
         "vue": "^2.5.22",
+        "vue-js-modal": "^1.3.33",
         "vue-resize": "^0.4.5",
         "vue-router": "^3.0.1",
         "vuex": "^3.0.1"
@@ -8536,9 +8578,9 @@
       "optional": true
     },
     "popper.js": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
-      "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "portfinder": {
       "version": "1.0.24",
@@ -10967,6 +11009,11 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -11342,12 +11389,12 @@
       "dev": true
     },
     "v-tooltip": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/v-tooltip/-/v-tooltip-2.0.2.tgz",
-      "integrity": "sha512-xQ+qzOFfywkLdjHknRPgMMupQNS8yJtf9Utd5Dxiu/0n4HtrxqsgDtN2MLZ0LKbburtSAQgyypuE/snM8bBZhw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/v-tooltip/-/v-tooltip-2.0.3.tgz",
+      "integrity": "sha512-KZZY3s+dcijzZmV2qoDH4rYmjMZ9YKGBVoUznZKQX0e3c2GjpJm3Sldzz8HHH2Ud87JqhZPB4+4gyKZ6m98cKQ==",
       "requires": {
-        "lodash": "^4.17.11",
-        "popper.js": "^1.15.0",
+        "lodash": "^4.17.15",
+        "popper.js": "^1.16.0",
         "vue-resize": "^0.4.5"
       }
     },
@@ -11438,6 +11485,11 @@
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true
+    },
+    "vue-js-modal": {
+      "version": "1.3.33",
+      "resolved": "https://registry.npmjs.org/vue-js-modal/-/vue-js-modal-1.3.33.tgz",
+      "integrity": "sha512-AeYn51cG/iSZbRAOnDrmzdv+Q8bBtElB3R0U37eM3NRKkcFsf6CLBw5lip1sSbichdn1ANfzjM+N1gki3GvMqw=="
     },
     "vue-loader": {
       "version": "15.7.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "core-js": "^2.6.5",
     "d3-format": "^1.4.2",
     "d3-scale": "^3.1.0",
-    "library": "github:SensesProject/library#1.2.0",
+    "library": "github:SensesProject/library",
     "marked": "^0.7.0",
     "unfetch": "^4.1.0",
     "vue": "^2.6.10",

--- a/public/configs/debugReferenceMissingRegionalInfo.json
+++ b/public/configs/debugReferenceMissingRegionalInfo.json
@@ -15,7 +15,9 @@
     "options": [{
       "label": "Where do we have to go?",
       "variables": [
-        "Primary Energy|Coal"
+        "Primary Energy|Coal",
+        "Primary Energy|Oil",
+        "Primary Energy|Gas"
       ]      ,
     "regions": [
       "World",
@@ -28,27 +30,27 @@
       "groups": [{
         "label": "World",
         "img": "/maps/World.png",
-        "size": 4
+        "size": 3
       }, {
         "label": "R5 Asia",
         "img": "/maps/ASIA.png",
-        "size": 4
+        "size": 3
       }, {
         "label": "R5 Latin America",
         "img": "/maps/LAM.png",
-        "size": 4
+        "size": 3
       }, {
         "label": "R5 MAF",
         "img": "/maps/MAF.png",
-        "size": 4
+        "size": 3
       }, {
         "label": "R5 OECD90 +EU ",
         "img": "/maps/OECD90+EU.png",
-        "size": 4
+        "size": 3
       }, {
         "label": "R5 REF",
         "img": "/maps/REF.png",
-        "size": 4
+        "size": 3
       }]
     }
   ]

--- a/public/gems.json
+++ b/public/gems.json
@@ -1,0 +1,18 @@
+[{
+  "id": "stocktake-1",
+  "dir": "stocktake-1",
+  "gems": [
+    {"id": "stocktake-models_WhereDoWeWantToGo", "title": "Where do we want to go"},
+    {"id": "stocktake-models_HowDoWeGetThere_Energy", "title": "How do we get there (Energy)"},
+    {"id": "stocktake-models_HowDoWeGetThere_Money", "title": "How do we get there (Money)"},
+    {"id": "stocktake-sensitivities-policy", "title": "scenario sensitivities"},
+    {"id": "stocktake-sensitivities-CDR_avail", "title": "sensitivities CDR"}
+  ]
+}, {
+  "title": "examples",
+  "dir": "examples",
+  "gems": [
+    {"id": "example-options-simple"},
+    {"id": "example-options-multi-dropdown"}
+  ]
+}]

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,10 +5,17 @@
   </div>
 </template>
 <script>
+import { mapActions } from 'vuex'
 import SensesMenu from 'library/src/components/SensesMenu.vue'
 export default {
   components: {
     SensesMenu
+  },
+  methods: {
+    ...mapActions(['fetchGems'])
+  },
+  created () {
+    this.fetchGems()
   }
 }
 </script>

--- a/src/router.js
+++ b/src/router.js
@@ -12,7 +12,12 @@ export default new Router({
       component: Home
     },
     {
-      path: '/:gem',
+      path: '/:module',
+      name: 'module',
+      component: Home
+    },
+    {
+      path: '/:module/:gem',
       name: 'gem',
       component: () => import(/* webpackChunkName: "gem" */ './views/Gem.vue')
     }

--- a/src/views/Gem.vue
+++ b/src/views/Gem.vue
@@ -60,7 +60,14 @@
           </template>
         </table>
       </div>
-      </template>
+      <div v-if="related">
+        More on that topic
+        <ul>
+          <li v-if="related.module.link"><a :href="related.module.link">Read the module</a></li>
+          <li v-for="(link, i) in related.gems" :key="`l-${i}`"><router-link :to="link.path">{{ link.title }}</router-link></li>
+        </ul>
+      </div>
+    </template>
   </div>
 </template>
 <script>
@@ -83,7 +90,7 @@ export default {
     SensesRadio
   },
   computed: {
-    ...mapState(['config', 'colors', 'data', 'metadata', 'current', 'domains']),
+    ...mapState(['config', 'colors', 'data', 'metadata', 'current', 'domains', 'gems', 'modules']),
     ...mapGetters(['dict']),
     ...bindState(['options']),
     docs () {
@@ -104,6 +111,19 @@ export default {
           data: d
         }
       })
+    },
+    related () {
+      const { $route, gems } = this
+      const module = gems.find(g => g.dir === $route.params.module)
+      if (module == null) return null
+      const relatedGems = module.gems.filter(gem => gem.id !== $route.params.gem).map(gem => ({
+        title: gem.title || gem.id,
+        path: `${module.dir}/${gem.id}`
+      }))
+      return {
+        gems: relatedGems,
+        module
+      }
     }
   },
   methods: {

--- a/src/views/Gem.vue
+++ b/src/views/Gem.vue
@@ -1,4 +1,4 @@
-<template>
+  <template>
   <div class="gem">
     <template v-if="config">
       <section class="intro">

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,25 +1,42 @@
 <template>
   <div class="home">
+    <h1>{{ module.title }}</h1>
     <ul>
-      <li v-for="gem in gems" :key="gem"><router-link :to="gem">{{ gem }}</router-link></li>
+      <li v-for="(gem, i) in module.gems" :key="`g-${i}`"><router-link :to="gem.path">{{ gem.title || gem.id }}</router-link></li>
+    </ul>
+    <br>
+    <ul v-if="module.link != null">
+      <li>More on that topic</li>
+      <li><router-link :to="module.link">→ Read the module</router-link></li>
     </ul>
   </div>
 </template>
 
 <script>
-import { mapState, mapActions } from 'vuex'
+import { mapState } from 'vuex'
 export default {
   name: 'home',
   components: {
   },
   computed: {
-    ...mapState(['gems'])
-  },
-  methods: {
-    ...mapActions(['fetchGems'])
-  },
-  created () {
-    this.fetchGems()
+    ...mapState(['gems', 'modules']),
+    module () {
+      const { $route, gems } = this
+      const module = gems.find(g => g.dir === $route.params.module)
+      if (module == null) {
+        return {
+          title: 'Guided Explore Modules',
+          gems: gems.map(({ title, dir }) => ({ title, path: dir }))
+        }
+      }
+      return {
+        ...module,
+        gems: module.gems.map(gem => ({
+          ...gem,
+          path: `${module.dir}/${gem.id}`
+        }))
+      }
+    }
   }
 }
 </script>


### PR DESCRIPTION
this is implementing the functionality of the brace feature #17 
styling will follow…

this update changes urls from `/#/[gem]` → `/#/[dir]/[gem]` where `dir` specifies the collection of gems. e.g; `/#/stocktake-models_HowDoWeGetThere_Money` → `/#/stocktake-1/stocktake-models_HowDoWeGetThere_Money`

this update makes `/public/configlist.csv` obsolete and uses `/public/gems.json` for data on available modules.

A gem collection can either be linked to a module from the senses-toolkit or standalone. If it's linked to a module the property `id` (see https://github.com/SensesProject/share/blob/master/settings/modules.json) must be given. If not a title for the collection should be provided.

the property `dir` is required and is part of the url for gem-collections (`/#/[dir]`) and gems (`/#/[dir]/[gem]`).
the property `gems` is an array containing an object with an `id` (required) for each gem and a title (optional)

Example:
```
[{
  "id": "stocktake-1",
  "dir": "stocktake-1",
  "gems": [
    {"id": "stocktake-models_WhereDoWeWantToGo", "title": "Where do we want to go"},
    {"id": "stocktake-models_HowDoWeGetThere_Energy", "title": "How do we get there (Energy)"},
    {"id": "stocktake-models_HowDoWeGetThere_Money", "title": "How do we get there (Money)"},
    {"id": "stocktake-sensitivities-policy", "title": "scenario sensitivities"},
    {"id": "stocktake-sensitivities-CDR_avail", "title": "sensitivities CDR"}
  ]
}, {
  "title": "examples",
  "dir": "examples",
  "gems": [
    {"id": "example-options-simple"},
    {"id": "example-options-multi-dropdown"}
  ]
}]
``` 
